### PR TITLE
Change psycopg2 requirement to >=2.6.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-psycopg2>=2.6.2
+psycopg2>=2.6.2,<3
 Django>=1.8,<2
 enum34==1.1.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-psycopg2==2.6.2
+psycopg2>=2.6.2
 Django>=1.8,<2
 enum34==1.1.6


### PR DESCRIPTION
make setup failed with PostgreSQL 10.0 due to psycopg2 2.6.2 not
being able to find it. Newer versions can find PostgreSQL 10.0
without a problem.