### PR TITLE
Perform non_void anti-join using foreign key column.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .tox
 *.egg-info/*
 *.eggs
+build/*
 docs/_build/*
 dist/*
 pbr-*.egg/

--- a/capone/models.py
+++ b/capone/models.py
@@ -70,7 +70,7 @@ class MatchType(Enum):
 class TransactionQuerySet(models.QuerySet):
     def non_void(self):
         return self.filter(
-            voided_by__isnull=True,
+            voided_by__voids_id__isnull=True,
             voids__isnull=True,
         )
 


### PR DESCRIPTION
@hrichards @lucaswiman Postgres 9.6 tends to make better query plans on anti-joins when the constraint uses the column involved in the foreign key. See this [thread](https://www.postgresql.org/message-id/flat/CAPRbp06%2Bfgvpr70mq6rnkPhhW6i%2By2168dwHkGy0rc3k7cZk2w%40mail.gmail.com#CAPRbp06+fgvpr70mq6rnkPhhW6i+y2168dwHkGy0rc3k7cZk2w@mail.gmail.com) on the postgres mailing list for details.

This PR updates the `non_void` to do just that. Tested by running the tests locally and running our internal tests against this version. Also installing to a test machine and running queries that use this method.

A query that takes ~10s on 9.6 now takes ~1s. I don't think this is likely to cause issues with other databases as the index on the foreign key is what you'd want to be used here in general.