### PR TITLE
Do not bother pinning enum34

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 psycopg2>=2.6.2,<3
 Django>=1.8,<2
-enum34==1.1.6
+enum34


### PR DESCRIPTION
it's not useful to pin enum34. It's not really a library that changes and all it does is make it *intensely* painful to use this library in other set ups.

Blocks use of pipenv on Counsyl's website.

@jdavisp3 @hrichards 