### PR TITLE
Sem-ver: api-break. Dropped 1.11 support and added 2.2 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,8 @@
 - Add Django 2.2 support.
 - Fix some circularities and inefficiencies in the Makefile
 - "Cap" some older dev dependencies whose more recent versions don't work with Capone's current version.
+
+
+# 2.0.3
+
+This version is a mis-numbered version of 3.0.0 that was released accidentally.


### PR DESCRIPTION
Trying a non-empty commit to bump the major version.